### PR TITLE
Implement De-duplication in a Background Thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ huge-data.json
 big-data.json
 med-data.json
 parse-firebase-json
+prod-firebase-data.json
 parse-firebase-json.dSYM
 search-huge-file-for
 search-huge-file-for.dSYM


### PR DESCRIPTION
De-duplication radically reduces the amount of data that must be stored, BUT it requires two more JSON parsing passes to achieve (table-level parse for a deep JSON equality check, and a record level parse because that's a JSON string in the firebase schema, not a JSON object).

Because JSON parsing is inherently single-threaded, and the bottleneck is (sometimes) the main parsing thread, it might be advantageous to offload secondary and tertiary JSON parsing passes to a background thread. This is a little complicated because we already have 4x-8x background threads doing MySQL upload, and this will sit between them when the dedupe in BG option is selected during compilation.

Initial implementation seems to be working, but performance is not substantially improved (yet). Need to debug why this isn't a major improvement, because it should be 🤔